### PR TITLE
Use functional options pattern to configure Twikey Client

### DIFF
--- a/example/simple.go
+++ b/example/simple.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/twikey/twikey-api-go"
+	"log"
+	"os"
+)
+
+func main() {
+	client := twikey.NewClient(os.Getenv("TWIKEY_API_KEY"))
+
+	ctx := context.Background()
+	invite, err := client.DocumentSign(ctx, &twikey.InviteRequest{
+		Template:       "YOUR_TEMPLATE_ID",
+		CustomerNumber: "123",
+		Email:          "john@doe.com",
+		Language:       "en",
+		Lastname:       "Doe",
+		Firstname:      "John",
+		Address:        "Abbey Road",
+		City:           "Liverpool",
+		Zip:            "1562",
+		Country:        "EN",
+		Iban:           "GB32BARC20040198915359",
+		Bic:            "GEBEBEB",
+		Method:         "sms",
+		Extra: map[string]string{
+			"SomeKey": "VALUE",
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(invite.Url)
+}

--- a/session.go
+++ b/session.go
@@ -48,7 +48,7 @@ func generateOtp(_salt string, _privKey string) (int, error) {
 
 func (c *Client) refreshTokenIfRequired() error {
 
-	if c.timeProvider.Now().Sub(c.lastLogin).Hours() < 23 {
+	if c.TimeProvider.Now().Sub(c.lastLogin).Hours() < 23 {
 		return nil
 	}
 
@@ -71,7 +71,7 @@ func (c *Client) refreshTokenIfRequired() error {
 			if resp.StatusCode == 200 && token != nil {
 				c.Debug.Println("Connected to", c.BaseURL, "with token", token[0])
 				c.apiToken = token[0]
-				c.lastLogin = c.timeProvider.Now()
+				c.lastLogin = c.TimeProvider.Now()
 				return nil
 			} else if resp.StatusCode > 500 {
 				c.Debug.Println("General error", resp.StatusCode, resp.Status)

--- a/session_test.go
+++ b/session_test.go
@@ -35,7 +35,7 @@ func TestClient_refreshTokenIfRequired(t *testing.T) {
 		HTTPClient: &http.Client{
 			Timeout: time.Minute,
 		},
-		timeProvider: &ttp,
+		TimeProvider: &ttp,
 		Debug:        log.Default(),
 	}
 	c.BaseURL = getEnv("TWIKEY_URL", "https://api.beta.twikey.com")

--- a/twikey_test.go
+++ b/twikey_test.go
@@ -1,6 +1,7 @@
 package twikey
 
 import (
+	"log"
 	"os"
 	"testing"
 )
@@ -9,6 +10,40 @@ func newTestClient() *Client {
 	c := NewClient(os.Getenv("TWIKEY_API_KEY"))
 	c.BaseURL = getEnv("TWIKEY_URL", "https://api.beta.twikey.com")
 	return c
+}
+
+func TestClientWithBasicFunctionalOptions(t *testing.T) {
+	salt := "salty"
+	baseUrl := "http://localtest.me"
+	userAgent := "someUserAgent"
+	apikey := "123"
+
+	c := NewClient(apikey,
+		WithBaseURL(baseUrl),
+		WithSalt(salt),
+		WithUserAgent(userAgent),
+		WithLogger(log.Default()),
+	)
+
+	if c.APIKey != apikey {
+		t.Fatalf("Expected client ApiKey to be %s but was %s", apikey, c.APIKey)
+	}
+
+	if c.BaseURL != baseUrl {
+		t.Fatalf("Expected client BaseURL to be %s but was %s", baseUrl, c.BaseURL)
+	}
+
+	if c.Salt != salt {
+		t.Fatalf("Expected client Salt to be %s but was %s", salt, c.Salt)
+	}
+
+	if c.UserAgent != userAgent {
+		t.Fatalf("Expected client UserAgent to be %s but was %s", userAgent, c.UserAgent)
+	}
+
+	if c.Debug != log.Default() {
+		t.Fatalf("Expected the default logger from log to be used")
+	}
 }
 
 func TestTwikeyClient_verifyWebhook(t *testing.T) {


### PR DESCRIPTION
Use the same defaults as before and use functional options to configure the client if so desired. Allow the option to disable Logging by providing the NullLogger, and make TimeProvider public as before if was not possible to create your own client without the constructor which also set the logger to discard.