### PR TITLE
Add support for subscriptions

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -28,11 +28,11 @@ func NewTwikeyError(code string, msg string, extra string) *TwikeyError {
 
 func NewTwikeyErrorFromResponse(res *http.Response) *TwikeyError {
 	if res.StatusCode == 400 {
-		errcode := res.Header["Apierror"][0]
+		code := res.Header.Get("ApiError")
 		return &TwikeyError{
 			Status:  res.StatusCode,
-			Code:    errcode,
-			Message: errcode,
+			Code:    code,
+			Message: code,
 		}
 	}
 	return &TwikeyError{

--- a/subscription.go
+++ b/subscription.go
@@ -1,0 +1,293 @@
+package twikey
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type Recurrence string
+
+const (
+	RecurrenceWeekly     Recurrence = "1w"
+	RecurrenceMonthly    Recurrence = "1m"
+	RecurrenceBiMonthly  Recurrence = "2m"
+	RecurrenceQuarterly  Recurrence = "3m"
+	RecurrenceTrimestral Recurrence = "4m"
+	RecurrenceSemiAnnual Recurrence = "6m"
+	RecurrenceAnnual     Recurrence = "12m"
+)
+
+type SubscriptionState string
+
+const (
+	SubscriptionStateActive    SubscriptionState = "active"
+	SubscriptionStateSuspended SubscriptionState = "suspended"
+	SubscriptionStateCancelled SubscriptionState = "cancelled"
+	SubscriptionStateClosed    SubscriptionState = "closed"
+)
+
+type Subscription struct {
+	Id         int               `json:"id"`
+	State      SubscriptionState `json:"state"`
+	Amount     float64           `json:"amount"`
+	Message    string            `json:"message"`
+	Ref        string            `json:"ref"`
+	Plan       int               `json:"plan"`
+	Runs       int               `json:"runs"`
+	StopAfter  int               `json:"stopAfter"`
+	Start      string            `json:"start"`
+	Next       string            `json:"next"`
+	Recurrence Recurrence        `json:"recurrence"`
+	MndtId     string            `json:"mndtId"`
+}
+
+type SubscriptionAddRequest struct {
+	// Unique key usable only once per request every 24hrs.
+	IdempotencyKey string
+	// Mandate reference for which to add the subscription to.
+	MndtId string
+	// The message the subscriber will see.
+	Message string
+	// Name of the base plan.
+	Plan string
+	// Reference of the subscription (important for updates), it is converted to uppercase and can't contain any spaces.
+	Ref string
+	// Amount of the transaction.
+	Amount float64
+	// Number of time the subscription should be executed. Set to a value lower than 1 for an unbounded subscription.
+	StopAfter int
+	// The frequency of the subscription, by default it will be monthly.
+	Recurrence Recurrence
+	// Start of subscription eg. 2022-11-01 (only future dates are allowed).
+	StartDate string
+}
+
+// asUrlParams returns the form URL encoded parameters for the incoming request.
+func (r *SubscriptionAddRequest) asUrlParams() string {
+	params := url.Values{}
+	params.Add("mndtId", r.MndtId)
+	params.Add("message", r.Message)
+	params.Add("amount", fmt.Sprintf("%.2f", r.Amount))
+	params.Add("start", r.StartDate)
+	if r.Plan != "" {
+		params.Add("plan", r.Plan)
+	}
+	if r.Ref != "" {
+		params.Add("ref", r.Ref)
+	}
+	if r.StopAfter > 0 {
+		params.Add("stopAfter", strconv.Itoa(r.StopAfter))
+	}
+	if r.Recurrence != "" {
+		params.Add("recurrence", string(r.Recurrence))
+	}
+	return params.Encode()
+}
+
+// SubscriptionAdd will add a subscription to an existing agreement. This means than when the subscription is run a
+// new transaction will automatically be created using the defined schedule.
+func (c *Client) SubscriptionAdd(ctx context.Context, payload *SubscriptionAddRequest) (*Subscription, error) {
+	input := strings.NewReader(payload.asUrlParams())
+	endpoint := c.BaseURL + "/creditor/subscription"
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, input)
+	if payload.IdempotencyKey != "" {
+		req.Header.Set("Idempotency-Key", payload.IdempotencyKey)
+	}
+
+	var output Subscription
+	if err := c.sendRequest(req, &output); err != nil {
+		return nil, err
+	}
+	return &output, nil
+}
+
+type UpdateSubscriptionRequest struct {
+	// The mandate reference of the subscription, creates a new subscription when different from current id.
+	MndtId string
+	// Message to the subscriber.
+	Message string
+	// Amount of the transaction.
+	Amount float64
+	// Start date of the subscription (yyyy-mm-dd). This is also the first execution date. Only a future date is accepted.
+	Start string
+	// Name of the base plan, When passing a plan the values of message, amount and recurrence are ignored if passed during the request.
+	Plan string
+	// The frequency of the subscription, by default it will be monthly.
+	Recurrence Recurrence
+	// Number of times to execute. Previous executions (runs) are not taken into account for the new subscription. It starts from 0 runs.
+	StopAfter int
+}
+
+func (r *UpdateSubscriptionRequest) asUrlParams() string {
+	params := url.Values{}
+	params.Add("mndtId", r.MndtId)
+	params.Add("message", r.Message)
+	params.Add("amount", fmt.Sprintf("%.2f", r.Amount))
+	params.Add("start", r.Start)
+	if r.Plan != "" {
+		params.Add("plan", r.Plan)
+	}
+	if r.Recurrence != "" {
+		params.Add("recurrence", string(r.Recurrence))
+	}
+	if r.StopAfter > 0 {
+		params.Add("stopAfter", strconv.Itoa(r.StopAfter))
+	}
+	return params.Encode()
+}
+
+// SubscriptionUpdate will update a subscription. This endpoint allows the update by using the previously passed reference
+// for a specific agreement. The update subscription and patch subscription are similar requests, the difference be that
+// with the [Client.SubscriptionUpdate] you can replace a subscription (cancel current and start new) the [Client.SubscriptionPatch] can't replace a subscription.
+func (c *Client) SubscriptionUpdate(ctx context.Context, mandate string, ref string, payload *UpdateSubscriptionRequest) (*Subscription, error) {
+	if mandate == "" || ref == "" {
+		return nil, errors.New("mandate reference and subscription reference are required")
+	}
+
+	input := strings.NewReader(payload.asUrlParams())
+	endpoint := fmt.Sprintf("%s/creditor/subscription/%s/%s", c.BaseURL, mandate, ref)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, input)
+	var output Subscription
+	if err := c.sendRequest(req, &output); err != nil {
+		return nil, err
+	}
+	return &output, nil
+}
+
+type PatchSubscriptionRequest struct {
+	// Move the subscription to a different mandate.
+	MndtId string
+	// message to the subscriber.
+	Message string
+	// Amount of the transaction that will be created based on the subscription recurrence.
+	Amount float64
+}
+
+func (r *PatchSubscriptionRequest) asUrlParams() string {
+	params := url.Values{}
+	if r.MndtId != "" {
+		params.Add("mndtId", r.MndtId)
+	}
+	if r.Message != "" {
+		params.Add("message", r.Message)
+	}
+	if r.Amount > 0 {
+		params.Add("amount", fmt.Sprintf("%.2f", r.Amount))
+	}
+	return params.Encode()
+}
+
+// SubscriptionPatch will update the subscription without replacing it. It allows you to update specific fields or move the subscription to a different mandate.
+func (c *Client) SubscriptionPatch(ctx context.Context, mandate string, ref string, payload *PatchSubscriptionRequest) (*Subscription, error) {
+	input := payload.asUrlParams()
+	endpoint := fmt.Sprintf("%s/creditor/subscription/%s/%s?%s", c.BaseURL, mandate, ref, input)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPatch, endpoint, nil)
+	var output Subscription
+	if err := c.sendRequest(req, &output); err != nil {
+		return nil, err
+	}
+	return &output, nil
+}
+
+// SubscriptionCancel subscription can be cancelled by using its ref for a specific agreement.
+func (c *Client) SubscriptionCancel(ctx context.Context, mandate string, ref string) error {
+	endpoint := fmt.Sprintf("%s/creditor/subscription/%s/%s", c.BaseURL, mandate, ref)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	return c.sendRequest(req, nil) // no content response
+}
+
+// SubscriptionDetail retrieves a single subscription for a specific agreement.
+func (c *Client) SubscriptionDetail(ctx context.Context, mandate string, ref string) (*Subscription, error) {
+	endpoint := fmt.Sprintf("%s/creditor/subscription/%s/%s", c.BaseURL, mandate, ref)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	var output Subscription
+	if err := c.sendRequest(req, &output); err != nil {
+		return nil, err
+	}
+	return &output, nil
+}
+
+type SubscriptionListRequest struct {
+	// Mandate reference
+	MndtId string
+	// CustomerNumber specifies the reference of a customer.
+	CustomerNumber string
+	// State of the subscription (active, suspended, cancelled, closed)
+	State SubscriptionState
+	// Page of the results (if more than 1 is available)
+	Page int
+}
+
+func (r *SubscriptionListRequest) asUrlParams() string {
+	params := url.Values{}
+	if r.MndtId != "" {
+		params.Add("mndtId", r.MndtId)
+	}
+	if r.CustomerNumber != "" {
+		params.Add("customerNumber", r.CustomerNumber)
+	}
+	if r.State != "" {
+		params.Add("state", string(r.State))
+	}
+	if r.Page > 0 {
+		params.Add("page", strconv.Itoa(r.Page))
+	}
+	return params.Encode()
+}
+
+// NextPage will increment the current page number of the subscription list request.
+func (r *SubscriptionListRequest) NextPage() *SubscriptionListRequest {
+	r.Page++
+	return r
+}
+
+type SubscriptionListResponse struct {
+	Subscriptions []Subscription `json:"Subscriptions"`
+	Links         struct {
+		Previous string `json:"previous"`
+		Self     string `json:"self"`
+		Next     string `json:"next"`
+	} `json:"_links"`
+}
+
+// HasNext will return true if another page of results is available.
+func (r *SubscriptionListResponse) HasNext() bool {
+	return r.Links.Next != ""
+}
+
+// SubscriptionList retrieves all subscriptions matching the query.
+func (c *Client) SubscriptionList(ctx context.Context, payload *SubscriptionListRequest) (*SubscriptionListResponse, error) {
+	input := payload.asUrlParams()
+	endpoint := c.BaseURL + "/creditor/subscription/query"
+	if input != "" {
+		endpoint += "?" + input
+	}
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	var output SubscriptionListResponse
+	if err := c.sendRequest(req, &output); err != nil {
+		return nil, err
+	}
+	return &output, nil
+}
+
+// SubscriptionSuspend will suspend the referenced subscription.
+func (c *Client) SubscriptionSuspend(ctx context.Context, mandate string, ref string) error {
+	return c.subscriptionAction(ctx, mandate, ref, "suspend")
+}
+
+// SubscriptionResume will resume the currently suspended subscription.
+func (c *Client) SubscriptionResume(ctx context.Context, mandate string, ref string) error {
+	return c.subscriptionAction(ctx, mandate, ref, "resume")
+}
+
+// subscriptionAction will perform the given action on the referenced subscription.
+func (c *Client) subscriptionAction(ctx context.Context, mandate string, ref string, action string) error {
+	endpoint := fmt.Sprintf("%s/creditor/subscription/%s/%s/%s", c.BaseURL, mandate, ref, action)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, nil)
+	return c.sendRequest(req, nil)
+}

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -1,0 +1,392 @@
+package twikey
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func NewMockedTestClient(server *httptest.Server) *Client {
+	cl := NewClient("TEST_API_KEY")
+	cl.BaseURL = server.URL
+
+	// already set authorization token + last login
+	cl.apiToken = "api-token"
+	cl.lastLogin = time.Now()
+
+	return cl
+}
+
+func AssertEquals(t *testing.T, expected interface{}, actual interface{}) {
+	t.Helper() // marks this function as a helper function -> hides caller reference.
+	if expected != actual {
+		t.Errorf("Expected %v, got %v", expected, actual)
+	}
+}
+
+func TestHasNext(t *testing.T) {
+	res := &SubscriptionListResponse{}
+	res.Links.Next = "https://..."
+	if !res.HasNext() {
+		t.Errorf("Expected HasNext() to have returned true when a next link is available")
+	}
+}
+
+func TestSubscriptionAdd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		AssertEquals(t, http.MethodPost, r.Method)
+		AssertEquals(t, "/creditor/subscription", r.URL.Path)
+		AssertEquals(t, "my-idempotency-key", r.Header.Get("Idempotency-Key"))
+		AssertEquals(t, "api-token", r.Header.Get("Authorization"))
+
+		// check request body
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("failed to parse form parameters")
+			t.FailNow()
+		}
+
+		AssertEquals(t, "Monthly subscription", r.Form.Get("message"))
+		AssertEquals(t, "MyRef", r.Form.Get("ref"))
+		AssertEquals(t, "12.00", r.Form.Get("amount"))
+		AssertEquals(t, "1m", r.Form.Get("recurrence"))
+		AssertEquals(t, "2022-11-29", r.Form.Get("start"))
+
+		json := `{
+    "id": 10,
+    "state": "active",
+    "amount": 12.0,
+    "message": "Monthly subscription",
+    "ref": "MyRef",
+    "plan": 0,
+    "runs": 0,
+    "stopAfter": 5,
+    "start": "2022-11-29",
+    "next": "2022-12-01",
+    "recurrence": "1m",
+    "mndtId": "TEST03"
+}`
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(json))
+	}))
+	defer server.Close()
+	cl := NewMockedTestClient(server)
+
+	ctx := context.TODO()
+	output, err := cl.SubscriptionAdd(ctx, &SubscriptionAddRequest{
+		IdempotencyKey: "my-idempotency-key",
+		MndtId:         "TESTO3",
+		Message:        "Monthly subscription",
+		Ref:            "MyRef",
+		Amount:         12.00,
+		Recurrence:     RecurrenceMonthly,
+		StartDate:      "2022-11-29",
+	})
+	if err != nil {
+		t.Errorf("Error adding subscription: %s", err)
+		t.FailNow()
+	}
+
+	AssertEquals(t, 10, output.Id)
+	AssertEquals(t, SubscriptionStateActive, output.State)
+	AssertEquals(t, 12.0, output.Amount)
+	AssertEquals(t, "Monthly subscription", output.Message)
+	AssertEquals(t, "MyRef", output.Ref)
+	AssertEquals(t, 5, output.StopAfter)
+	AssertEquals(t, "2022-11-29", output.Start)
+	AssertEquals(t, "2022-12-01", output.Next)
+	AssertEquals(t, RecurrenceMonthly, output.Recurrence)
+	AssertEquals(t, "TEST03", output.MndtId)
+}
+
+func TestSubscriptionUpdate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		AssertEquals(t, http.MethodPost, r.Method)
+		AssertEquals(t, "/creditor/subscription/TST123/REF1", r.URL.Path)
+		AssertEquals(t, "api-token", r.Header.Get("Authorization"))
+
+		// check request body
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("failed to parse form parameters")
+			t.FailNow()
+		}
+
+		AssertEquals(t, "mymessage", r.Form.Get("message"))
+		AssertEquals(t, "planName", r.Form.Get("plan"))
+		AssertEquals(t, "10.22", r.Form.Get("amount"))
+
+		json := `{
+    "id": 10,
+    "state": "active",
+    "amount": 10.22,
+    "message": "mymessage",
+    "ref": "reference123",
+    "plan": 0,
+    "runs": 0,
+    "stopAfter": 5,
+    "start": "2022-11-29",
+    "next": "2022-12-01",
+    "recurrence": "1m",
+    "mndtId": "TEST03"
+}`
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(json))
+	}))
+	defer server.Close()
+	cl := NewMockedTestClient(server)
+
+	ctx := context.TODO()
+	output, err := cl.SubscriptionUpdate(ctx, "TST123", "REF1", &UpdateSubscriptionRequest{
+		Message: "mymessage",
+		Plan:    "planName",
+		Amount:  10.22,
+	})
+	if err != nil {
+		t.Errorf("Error updating subscription: %s", err)
+		t.FailNow()
+	}
+
+	AssertEquals(t, 10, output.Id)
+	AssertEquals(t, SubscriptionStateActive, output.State)
+	AssertEquals(t, 10.22, output.Amount)
+	AssertEquals(t, "mymessage", output.Message)
+	AssertEquals(t, "reference123", output.Ref)
+	AssertEquals(t, 5, output.StopAfter)
+	AssertEquals(t, "2022-11-29", output.Start)
+	AssertEquals(t, "2022-12-01", output.Next)
+	AssertEquals(t, RecurrenceMonthly, output.Recurrence)
+	AssertEquals(t, "TEST03", output.MndtId)
+}
+
+func TestSubscriptionPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		AssertEquals(t, http.MethodPatch, r.Method)
+		AssertEquals(t, "/creditor/subscription/TST123/REF1", r.URL.Path)
+		AssertEquals(t, "api-token", r.Header.Get("Authorization"))
+
+		// check request body
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("failed to parse form parameters")
+			t.FailNow()
+		}
+
+		AssertEquals(t, "MNDT200", r.Form.Get("mndtId"))
+		AssertEquals(t, "mymessage", r.Form.Get("message"))
+		AssertEquals(t, "25.00", r.Form.Get("amount"))
+
+		json := `{
+    "id": 10,
+    "state": "active",
+    "amount": 25.0,
+    "message": "mymessage",
+    "ref": "myreference",
+    "plan": 0,
+    "runs": 0,
+    "stopAfter": 5,
+    "start": "2024-11-29",
+    "next": "2024-12-01",
+    "recurrence": "1m",
+    "mndtId": "MNDT200"
+}
+`
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(json))
+	}))
+	defer server.Close()
+	cl := NewMockedTestClient(server)
+
+	ctx := context.TODO()
+	output, err := cl.SubscriptionPatch(ctx, "TST123", "REF1", &PatchSubscriptionRequest{
+		MndtId:  "MNDT200",
+		Message: "mymessage",
+		Amount:  25.00,
+	})
+	if err != nil {
+		t.Errorf("Error updating subscription: %s", err)
+		t.FailNow()
+	}
+	AssertEquals(t, 10, output.Id)
+	AssertEquals(t, SubscriptionStateActive, output.State)
+	AssertEquals(t, 25.0, output.Amount)
+	AssertEquals(t, "mymessage", output.Message)
+	AssertEquals(t, "myreference", output.Ref)
+	AssertEquals(t, 5, output.StopAfter)
+	AssertEquals(t, "2024-11-29", output.Start)
+	AssertEquals(t, "2024-12-01", output.Next)
+	AssertEquals(t, RecurrenceMonthly, output.Recurrence)
+	AssertEquals(t, "MNDT200", output.MndtId)
+}
+
+func TestSubscriptionCancel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		AssertEquals(t, http.MethodDelete, r.Method)
+		AssertEquals(t, "/creditor/subscription/TST123/REF1", r.URL.Path)
+		AssertEquals(t, "api-token", r.Header.Get("Authorization"))
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	cl := NewMockedTestClient(server)
+
+	ctx := context.TODO()
+	err := cl.SubscriptionCancel(ctx, "TST123", "REF1")
+	if err != nil {
+		t.Errorf("Error updating subscription: %s", err)
+		t.FailNow()
+	}
+}
+
+func TestSubscriptionDetail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		AssertEquals(t, http.MethodGet, r.Method)
+		AssertEquals(t, "/creditor/subscription/TST123/REF1", r.URL.Path)
+		AssertEquals(t, "api-token", r.Header.Get("Authorization"))
+
+		json := `{
+    "id": 10,
+    "state": "active",
+    "amount": 25.0,
+    "message": "mymessage",
+    "ref": "myreference",
+    "plan": 0,
+    "runs": 0,
+    "stopAfter": 5,
+    "start": "2024-11-29",
+    "next": "2024-12-01",
+    "recurrence": "1m",
+    "mndtId": "MNDT200"
+}
+`
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(json))
+	}))
+	defer server.Close()
+	cl := NewMockedTestClient(server)
+
+	ctx := context.TODO()
+	output, err := cl.SubscriptionDetail(ctx, "TST123", "REF1")
+	if err != nil {
+		t.Errorf("Error updating subscription: %s", err)
+		t.FailNow()
+	}
+	AssertEquals(t, 10, output.Id)
+	AssertEquals(t, SubscriptionStateActive, output.State)
+	AssertEquals(t, 25.0, output.Amount)
+	AssertEquals(t, "mymessage", output.Message)
+	AssertEquals(t, "myreference", output.Ref)
+	AssertEquals(t, 5, output.StopAfter)
+	AssertEquals(t, "2024-11-29", output.Start)
+	AssertEquals(t, "2024-12-01", output.Next)
+	AssertEquals(t, RecurrenceMonthly, output.Recurrence)
+	AssertEquals(t, "MNDT200", output.MndtId)
+}
+
+func TestSubscriptionList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		AssertEquals(t, http.MethodGet, r.Method)
+		AssertEquals(t, "/creditor/subscription/query", r.URL.Path)
+		AssertEquals(t, "api-token", r.Header.Get("Authorization"))
+
+		_page := r.URL.Query().Get("page")
+		if _page == "" {
+			// return first page
+			json := `{
+  "Subscriptions": [
+    {
+      "id": 10,
+      "state": "active",
+      "amount": 12.0,
+      "message": "Message for customer",
+      "ref": "MyRef",
+      "plan": 0,
+      "runs": 0,
+      "stopAfter": 5,
+      "start": "2022-10-29",
+      "last": "2022-11-29",
+      "next": "2022-12-01",
+      "recurrence": "1m",
+      "mndtId": "PLOPSAABO3"
+    }
+  ],
+  "_links": {
+    "next": "/creditor/subscription/query?page=1"
+  }
+}`
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(json))
+		} else {
+			// return empty page
+			json := `{
+  "Subscriptions": [],
+  "_links": {}
+}`
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(json))
+		}
+	}))
+	defer server.Close()
+	cl := NewMockedTestClient(server)
+	ctx := context.TODO()
+
+	payload := &SubscriptionListRequest{CustomerNumber: "cst1"}
+	first, err := cl.SubscriptionList(ctx, payload)
+	if err != nil {
+		t.Errorf("Error listing subscriptions: %s", err)
+		t.FailNow()
+	}
+
+	AssertEquals(t, 1, len(first.Subscriptions))
+	AssertEquals(t, true, first.HasNext())
+
+	second, err := cl.SubscriptionList(ctx, payload.NextPage())
+	if err != nil {
+		t.Errorf("Error listing subscriptions: %s", err)
+		t.FailNow()
+	}
+
+	AssertEquals(t, 0, len(second.Subscriptions))
+	AssertEquals(t, false, second.HasNext())
+}
+
+func TestSubscriptionSuspend(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		AssertEquals(t, http.MethodPost, r.Method)
+		AssertEquals(t, "/creditor/subscription/TST123/REF1/suspend", r.URL.Path)
+		AssertEquals(t, "api-token", r.Header.Get("Authorization"))
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	cl := NewMockedTestClient(server)
+	ctx := context.TODO()
+
+	err := cl.SubscriptionSuspend(ctx, "TST123", "REF1")
+	if err != nil {
+		t.Errorf("Error updating subscription: %s", err)
+		t.FailNow()
+	}
+}
+
+func TestSubscriptionResume(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		AssertEquals(t, http.MethodPost, r.Method)
+		AssertEquals(t, "/creditor/subscription/TST123/REF1/resume", r.URL.Path)
+		AssertEquals(t, "api-token", r.Header.Get("Authorization"))
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	cl := NewMockedTestClient(server)
+	ctx := context.TODO()
+
+	err := cl.SubscriptionResume(ctx, "TST123", "REF1")
+	if err != nil {
+		t.Errorf("Error updating subscription: %s", err)
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
Officially added support for the `/creditor/subscription` endpoints. The following methods have been added to the `twikey.Client`:
- `Client.SubscriptionAdd()`
- `Client.SubscriptionUpdate()`
- `Client.SubscriptionPatch()`
- `Client.SubscriptionCancel()`
- `Client.SubscriptionDetail()`
- `Client.SubscriptionList()`
- `Client.SubscriptionSuspend()`
- `Client.SubscriptionResume()`

### Bugfix
Plus I also fixed a potential `panic()` in the `NewTwikeyErrorFromResponse()` when testing via unit tests.